### PR TITLE
Fix request method override

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Sanity tests
         working-directory: ansible_collections/community/datapower
         run: |
-          ansible-test sanity --python ${{ matrix.python-version }} --failure-ok
+          ansible-test sanity --python ${{ matrix.python-version }}

--- a/ansible_collections/community/datapower/plugins/module_utils/datapower/requests.py
+++ b/ansible_collections/community/datapower/plugins/module_utils/datapower/requests.py
@@ -68,11 +68,11 @@ class Request:
         data = json.loads(unescape(resp_str))
         return data
 
-    def set_body(self, body):
-        self.body = body
+    def set_body(self, **kwargs):
+        self.body = kwargs.get('body', None)
 
-    def set_path(self, path):
-        self.path = path
+    def set_path(self, **kwargs):
+        self.path = kwargs.get('path', None)
 
     @staticmethod
     def join_path(*args, base_path=None):
@@ -106,14 +106,17 @@ class DirectoryRequest(Request):
     def __init__(self, connection):
         super().__init__(connection)
 
-    def set_path(self, domain, dir_path):
+    def set_path(self, **kwargs):
+        domain = kwargs['domain']
+        dir_path = kwargs['dir_path']
         self.path = self.join_path(
             domain,
             dir_path,
             base_path='/mgmt/filestore/'
         )
 
-    def set_body(self, dir_path):
+    def set_body(self, **kwargs):
+        dir_path = kwargs['dir_path']
         # drop root directory
         if dir_path.split('/')[0] == 'local':
             dir_path = '/'.join(dir_path.split('/')[1:])
@@ -137,11 +140,15 @@ class FileRequest(Request):
     def __init__(self, connection):
         super().__init__(connection)
 
-    def set_path(self, domain, file_path):
+    def set_path(self, **kwargs):
+        domain = kwargs['domain']
+        file_path = kwargs['file_path']
         self.path = self.join_path(
             domain, file_path, base_path='/mgmt/filestore/')
 
-    def set_body(self, file_path, content):
+    def set_body(self, **kwargs):
+        file_path = kwargs['file_path']
+        content = kwargs['content']
         file_name = posixpath.split(file_path)[1]
         self.body = {
             'file': {
@@ -158,20 +165,23 @@ class FileRequest(Request):
 
 
 class ListConfigObjectsRequest(Request):
+    # FIXME: Why is domain being passed and not used?
     def __init__(self, connection, domain='default'):
         super().__init__(connection)
-        self.set_path(domain)
+        self.set_path(domain=domain)
 
-    def set_path(self, domain='default'):
+    def set_path(self, **kwargs):
+        domain = kwargs['domain']
         self.path = self.join_path(base_path='/mgmt/config/')
 
 
 class ListActionsRequest(Request):
     def __init__(self, connection, domain='default'):
         super().__init__(connection)
-        self.set_path(domain)
+        self.set_path(domain=domain)
 
-    def set_path(self, domain='default'):
+    def set_path(self, **kwargs):
+        domain = kwargs.get('domain', 'default')
         self.path = self.join_path(
             domain,
             'operations',
@@ -184,12 +194,12 @@ class ConfigRequest(Request):
         super().__init__(connection)
         self.options = None
 
-    def set_path(self, domain=None, class_name=None, name=None, field=None):
+    def set_path(self, **kwargs):
         self.path = self.join_path(
-            domain,
-            class_name,
-            name,
-            field,
+            kwargs.get('domain', None),
+            kwargs.get('class_name', None),
+            kwargs.get('name', None),
+            kwargs.get('field', None),
             base_path='/mgmt/config/'
         )
 

--- a/ansible_collections/community/datapower/plugins/modules/config.py
+++ b/ansible_collections/community/datapower/plugins/modules/config.py
@@ -149,8 +149,8 @@ def run_module():
         config=config
     )
     req = ConfigRequest(connection)
-    req.set_path(domain, after.class_name, after.name)
-    req.set_body(after.config)
+    req.set_path(domain=domain, class_name=after.class_name, name=after.name)
+    req.set_body(body=after.config)
     result = {}
 
     try:

--- a/ansible_collections/community/datapower/plugins/modules/files.py
+++ b/ansible_collections/community/datapower/plugins/modules/files.py
@@ -136,14 +136,14 @@ def setup_file(module, dest, src=None, content=None):
 def build_reqs(connection, domain, dest, lf):
     parent_dir = get_parent_dir(dest)
     file_req = FileRequest(connection)
-    file_req.set_path(domain, dest)
+    file_req.set_path(domain=domain, file_path=dest)
 
     if lf:
-        file_req.set_body(dest, lf.get_base64())
+        file_req.set_body(file_path=dest, content=lf.get_base64())
 
     dir_req = DirectoryRequest(connection)
-    dir_req.set_body(parent_dir)
-    dir_req.set_path(domain, parent_dir)
+    dir_req.set_body(dir_path=parent_dir)
+    dir_req.set_path(domain=domain, dir_path=parent_dir)
     return dir_req, file_req
 
 

--- a/ansible_collections/community/datapower/plugins/modules/get_config.py
+++ b/ansible_collections/community/datapower/plugins/modules/get_config.py
@@ -205,7 +205,7 @@ def run_module():
 
     connection = Connection(module._socket_path)
     dp_req = ConfigRequest(connection)
-    dp_req.set_path(domain, class_name, name, field)
+    dp_req.set_path(domain=domain, class_name=class_name, name=name, field=field)
     dp_req.set_options(recursive=recursive, depth=depth, status=status)
     result = {}
     result['options'] = dp_req.options

--- a/ansible_collections/community/datapower/tests/unit/module_utils/datapower/test_requests.py
+++ b/ansible_collections/community/datapower/tests/unit/module_utils/datapower/test_requests.py
@@ -59,8 +59,8 @@ class TestFileRequest:
         file_path = 'local/dir/subdir/get.js'
         content = 'aGVsbG8gd29ybGQK'
         req = FileRequest(self.connection)
-        req.set_path(domain, file_path)
-        req.set_body(file_path, content)
+        req.set_path(domain=domain, file_path=file_path)
+        req.set_body(file_path=file_path, content=content)
         assert req.path == '/mgmt/filestore/default/local/dir/subdir/get.js'
         assert req.body == {'file': {'name': 'get.js', 'content': content}}
 
@@ -69,8 +69,8 @@ class TestFileRequest:
         file_path = 'local/dir/subdir/get.js'
         content = 'aGVsbG8gd29ybGQK'
         req = FileRequest(self.connection)
-        req.set_path(domain, file_path)
-        req.set_body(file_path, content)
+        req.set_path(domain=domain, file_path=file_path)
+        req.set_body(file_path=file_path, content=content)
 
         assert req.post()[0] == '/mgmt/filestore/default/local/dir/subdir'
         assert req.post()[1] == 'POST'
@@ -82,8 +82,8 @@ class TestFileRequest:
         file_path = 'local/dir/subdir/get.js'
         content = 'aGVsbG8gd29ybGQK'
         req = FileRequest(self.connection)
-        req.set_path(domain, file_path)
-        req.set_body(file_path, content)
+        req.set_path(domain=domain, file_path=file_path)
+        req.set_body(file_path=file_path, content=content)
         assert req.put()[
             0] == '/mgmt/filestore/default/local/dir/subdir/get.js'
         assert req.put()[1] == 'PUT'
@@ -94,8 +94,8 @@ class TestFileRequest:
         file_path = 'local/dir/subdir/get.js'
         content = 'aGVsbG8gd29ybGQK'
         req = FileRequest(self.connection)
-        req.set_path(domain, file_path)
-        req.set_body(file_path, content)
+        req.set_path(domain=domain, file_path=file_path)
+        req.set_body(file_path=file_path, content=content)
         assert req.get()[
             0] == '/mgmt/filestore/default/local/dir/subdir/get.js'
         assert req.get()[1] == 'GET'
@@ -106,8 +106,8 @@ class TestFileRequest:
         file_path = 'local/dir/subdir/get.js'
         content = 'aGVsbG8gd29ybGQK'
         req = FileRequest(self.connection)
-        req.set_path(domain, file_path)
-        req.set_body(file_path, content)
+        req.set_path(domain=domain, file_path=file_path)
+        req.set_body(file_path=file_path, content=content)
         assert req.delete()[
             0] == '/mgmt/filestore/default/local/dir/subdir/get.js'
         assert req.delete()[1] == 'DELETE'
@@ -123,8 +123,8 @@ class TestDirectoryRequest:
         dir_path = 'local/dir/subdir/'
 
         req = DirectoryRequest(self.connection)
-        req.set_body(dir_path)
-        req.set_path(domain, dir_path)
+        req.set_body(dir_path=dir_path)
+        req.set_path(domain=domain, dir_path=dir_path)
 
         assert req
         assert req.path == '/mgmt/filestore/default/local/dir/subdir'
@@ -134,8 +134,8 @@ class TestDirectoryRequest:
         domain = 'default'
         dir_path = 'local/dir/subdir/'
         req = DirectoryRequest(self.connection)
-        req.set_body(dir_path)
-        req.set_path(domain, dir_path)
+        req.set_body(dir_path=dir_path)
+        req.set_path(domain=domain, dir_path=dir_path)
         assert req.post()[0] == '/mgmt/filestore/default/local'
         assert req.post()[1] == 'POST'
         assert req.post()[2] == {'directory': {'name': 'dir/subdir/'}}
@@ -144,8 +144,8 @@ class TestDirectoryRequest:
         domain = 'default'
         dir_path = 'local/dir/subdir/'
         req = DirectoryRequest(self.connection)
-        req.set_body(dir_path)
-        req.set_path(domain, dir_path)
+        req.set_body(dir_path=dir_path)
+        req.set_path(domain=domain, dir_path=dir_path)
         try:
             req.put()
             assert False
@@ -156,8 +156,8 @@ class TestDirectoryRequest:
         domain = 'default'
         dir_path = 'local/dir/subdir/'
         req = DirectoryRequest(self.connection)
-        req.set_body(dir_path)
-        req.set_path(domain, dir_path)
+        req.set_body(dir_path=dir_path)
+        req.set_path(domain=domain, dir_path=dir_path)
         assert req.get()[0] == '/mgmt/filestore/default/local/dir/subdir'
         assert req.get()[1] == 'GET'
         assert not req.get()[2]
@@ -166,8 +166,8 @@ class TestDirectoryRequest:
         domain = 'default'
         dir_path = 'local/dir/subdir/'
         req = DirectoryRequest(self.connection)
-        req.set_body(dir_path)
-        req.set_path(domain, dir_path)
+        req.set_body(dir_path=dir_path)
+        req.set_path(domain=domain, dir_path=dir_path)
         assert req.delete()[0] == '/mgmt/filestore/default/local/dir/subdir'
         assert req.delete()[1] == 'DELETE'
         assert not req.delete()[2]
@@ -190,11 +190,11 @@ class TestConfigRequest:
     def test_ConfigRequest__init__(self):
         dp_req = ConfigRequest(self.connection)
         dp_req.set_path(
-            self.kwargs['domain'],
-            self.kwargs['class_name'],
-            self.kwargs['name'],
+            domain=self.kwargs['domain'],
+            class_name=self.kwargs['class_name'],
+            name=self.kwargs['name'],
         )
-        dp_req.set_body(self.kwargs['config'])
+        dp_req.set_body(body=self.kwargs['config'])
         assert dp_req.path == '/mgmt/config/default/CryptoValCred/valcred'
         assert dp_req.body == {
             "CryptoValCred": {
@@ -221,9 +221,9 @@ class TestConfigRequest:
         }
         dp_req = ConfigRequest(self.connection)
         dp_req.set_path(
-            self.kwargs['domain'],
-            self.kwargs['class_name'],
-            self.kwargs['name'],
+            domain=self.kwargs['domain'],
+            class_name=self.kwargs['class_name'],
+            name=self.kwargs['name'],
         )
         dp_req.set_options(**options)
         assert 'view=recursive' in dp_req.options
@@ -243,8 +243,8 @@ class TestConfigRequest:
         }
         dp = Config(**task_args)
         dp_req = ConfigRequest(self.connection)
-        dp_req.set_path(dp.domain, dp.class_name, dp.name)
-        dp_req.set_body(dp.config)
+        dp_req.set_path(domain=dp.domain, class_name=dp.class_name, name=dp.name)
+        dp_req.set_body(body=dp.config)
         assert dp_req.path == '/mgmt/config/default/CryptoValCred/valcred'
         assert dp_req.body == {
             "CryptoValCred": {
@@ -266,8 +266,8 @@ class TestConfigRequest:
 
         dp = Config(**task_args)
         dp_req = ConfigRequest(self.connection)
-        dp_req.set_path(dp.domain, dp.class_name, dp.name)
-        dp_req.set_body(dp.config)
+        dp_req.set_path(domain=dp.domain, class_name=dp.class_name, name=dp.name)
+        dp_req.set_body(body=dp.config)
         assert dp_req.path == '/mgmt/config/snafu/CryptoValCred/valcred'
         assert dp_req.body == {
             'CryptoValCred': {
@@ -287,8 +287,8 @@ class TestConfigRequest:
         }
         dp = Config(**task_args)
         dp_req = ConfigRequest(self.connection)
-        dp_req.set_path(dp.domain, dp.class_name, dp.name)
-        dp_req.set_body(dp.config)
+        dp_req.set_path(domain=dp.domain, class_name=dp.class_name, name=dp.name)
+        dp_req.set_body(body=dp.config)
         assert dp_req.path == '/mgmt/config/snafu/CryptoValCred/valcred'
 
     def test_ManageConfigRequest_invalid_class(self):


### PR DESCRIPTION
Fixes pylint argument-renamed for class Request set_path / set_body methods.  Replaced set_path / set_body parameters with **kwargs.