### PR TITLE
File req join path bugfix

### DIFF
--- a/ansible_collections/community/datapower/plugins/module_utils/datapower/requests.py
+++ b/ansible_collections/community/datapower/plugins/module_utils/datapower/requests.py
@@ -142,7 +142,7 @@ class FileRequest(Request):
 
     def set_path(self, **kwargs):
         domain = kwargs['domain']
-        file_path = kwargs['file_path']
+        file_path = kwargs['file_path'].strip('/')
         self.path = self.join_path(
             domain, file_path, base_path='/mgmt/filestore/')
 

--- a/ansible_collections/community/datapower/tests/unit/module_utils/datapower/test_requests.py
+++ b/ansible_collections/community/datapower/tests/unit/module_utils/datapower/test_requests.py
@@ -113,7 +113,6 @@ class TestFileRequest:
         assert req.delete()[1] == 'DELETE'
         assert not req.delete()[2]
 
-
     def test_FileRequest_set_path_strips_leading_forward_path(self):
         domain = 'default'
         file_path = '/local/dir/subdir/get.js'

--- a/ansible_collections/community/datapower/tests/unit/module_utils/datapower/test_requests.py
+++ b/ansible_collections/community/datapower/tests/unit/module_utils/datapower/test_requests.py
@@ -114,6 +114,20 @@ class TestFileRequest:
         assert not req.delete()[2]
 
 
+    def test_FileRequest_set_path_strips_leading_forward_path(self):
+        domain = 'default'
+        file_path = '/local/dir/subdir/get.js'
+        content = 'aGVsbG8gd29ybGQK'
+        req = FileRequest(self.connection)
+        req.set_path(domain=domain, file_path=file_path)
+        req.set_body(file_path=file_path, content=content)
+
+        assert req.post()[0] == '/mgmt/filestore/default/local/dir/subdir'
+        assert req.post()[1] == 'POST'
+        assert req.post()[2] == {
+            'file': {'name': 'get.js', 'content': content}}
+
+
 class TestDirectoryRequest:
     # Need a few more tests with potentially invalid input if handled incorrectly
     connection = MockConnection()


### PR DESCRIPTION
Fixes bug where if user passes file module arg dest with a leading / the associated req path url contains a //, which leads to an invalid url.
